### PR TITLE
fix peft import

### DIFF
--- a/src/llm_text_generation/model.py
+++ b/src/llm_text_generation/model.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 import torch
 from braceexpand import braceexpand
-from peft.mapping import get_peft_model
+from peft import get_peft_model
 from peft.peft_model import PeftModel
 from peft.tuners.lora import LoraConfig
 from text_utils.api import utils


### PR DESCRIPTION
the existing peft import breaks for newer versions of peft.

for old versions of peft, both works, so this fix shouldn't break anything

test:

python -c "from peft.mapping import get_peft_model"

python -c "from peft import get_peft_model"